### PR TITLE
Fix `isEmpty` types

### DIFF
--- a/source/is-empty.ts
+++ b/source/is-empty.ts
@@ -15,8 +15,8 @@ isEmpty([]);
 ```
 */
 /* eslint-disable @typescript-eslint/ban-types */
-export function isEmpty(array: unknown[]): array is [];
 export function isEmpty(array: readonly unknown[]): array is readonly [];
+export function isEmpty(array: unknown[]): array is [];
 export function isEmpty(array: readonly unknown[]): array is [] | readonly [] {
 	return array.length === 0;
 }

--- a/source/is-empty.ts
+++ b/source/is-empty.ts
@@ -14,7 +14,9 @@ isEmpty([]);
 //=> true
 ```
 */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export function isEmpty(array: readonly unknown[]): array is [] {
+/* eslint-disable @typescript-eslint/ban-types */
+export function isEmpty(array: unknown[]): array is [];
+export function isEmpty(array: readonly unknown[]): array is readonly [];
+export function isEmpty(array: readonly unknown[]): array is [] | readonly [] {
 	return array.length === 0;
 }

--- a/test/is-empty.ts
+++ b/test/is-empty.ts
@@ -4,4 +4,17 @@ import {isEmpty} from '../source/index.js';
 test('isEmpty()', t => {
 	t.false(isEmpty([1, 2, 3]));
 	t.true(isEmpty([]));
+
+	const immutable: readonly number[] = [1, 2, 3];
+
+	if (isEmpty(immutable)) {
+		// @ts-expect-error Should not change immutability
+		immutable.push(4 as never); // eslint-disable-line @typescript-eslint/no-unsafe-call
+	}
+
+	const mutable = [1, 2, 3];
+
+	if (!isEmpty(mutable)) {
+		mutable.push(4);
+	}
 });

--- a/test/is-empty.ts
+++ b/test/is-empty.ts
@@ -9,12 +9,12 @@ test('isEmpty()', t => {
 
 	if (isEmpty(immutable)) {
 		// @ts-expect-error Should not change immutability
-		immutable.push(4 as never); // eslint-disable-line @typescript-eslint/no-unsafe-call
+		immutable.pop(); // eslint-disable-line @typescript-eslint/no-unsafe-call
 	}
 
 	const mutable = [1, 2, 3];
 
 	if (!isEmpty(mutable)) {
-		mutable.push(4);
+		mutable.pop();
 	}
 });


### PR DESCRIPTION
This fixes a bug in the return type of `isEmpty` which would cast immutable arrays to mutable ones:


```ts
import {isEmpty} from 'ts-extras';

const immutable: readonly number[] = [1, 2, 3];

if (isEmpty(immutable)) {
	immutable.pop(); // should not compile!
}
```



<details><summary><b>Output</b></summary>

```ts
import { isEmpty } from 'ts-extras';
const immutable = [1, 2, 3];
if (isEmpty(immutable)) {
    immutable.pop(); // should not compile!
}

```


</details>


<details><summary><b>Compiler Options</b></summary>

```json
{
  "compilerOptions": {
    "strict": true,
    "noImplicitAny": true,
    "strictNullChecks": true,
    "strictFunctionTypes": true,
    "strictPropertyInitialization": true,
    "strictBindCallApply": true,
    "noImplicitThis": true,
    "noImplicitReturns": true,
    "alwaysStrict": true,
    "esModuleInterop": true,
    "declaration": true,
    "experimentalDecorators": true,
    "emitDecoratorMetadata": true,
    "target": "ES2017",
    "jsx": "react",
    "module": "ESNext",
    "moduleResolution": "node"
  }
}
```


</details>

**Playground Link:** [Provided](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAb2AZwKLhgTwL5wGZQQhwDkMyAtAKYAeMUAhsiQNwBQbAxhAHbLygQAVxgMARgBsqALjhQqDACa8JmODyEgxVKAG0AunAC8cXQEYANHABMVgMz72bYHjgAKFOjBYPIYaMkqAEogxDYASEERcSkAOkgwNyCWOAB6VLhkAAsIIQlFdQh4bnBgKQBCNmwgA)
      