### PR TITLE
Add `asSubtype`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn.lock
 distribution
+.idea

--- a/source/as-subtype.ts
+++ b/source/as-subtype.ts
@@ -1,0 +1,58 @@
+/**
+Cast the type of a variable to a subtype.
+
+This is useful in cases where the typescript engine is unable to catch certain implicit assertions.
+
+If a impossible type conversion is performed the result will be never.
+
+You cannot expand a type; you may only reduce or translate to a similar type.
+
+@example
+```ts
+// this is particularly useful in async actions and
+// other modern framework applications (e.g. react)
+let isDefined = true;
+const foo = "bar" as string | null;
+
+if (foo === null) {
+	isDefined = false;
+}
+
+if (!isDefined) {
+	//=> foo === string | null
+	asSubtype<string>(foo);
+	//=> foo === string
+}
+
+// you can also change between similar types
+const bar = ["bar"]
+//=> string[]
+asSubtype<[string]>(bar)
+//=> [string]
+asSubtype<["bar"]>(bar)
+//=> ["bar"]
+
+// this can also break typescript invariants
+asSubtype<["string"]>(bar)
+//=> ["string"]
+// but only to a certain degree
+asSubtype<string>(bar)
+// => never
+asSubtype<number>("string")
+//=> never
+asSubtype<undefined>("string" as string | null)
+//=> never
+
+// You can only increase precision
+const baz = "baz" as string | null;
+asSubtype<string>(baz)
+//=> string
+asSubtype<null | string>(baz)
+//=> string
+```
+ */
+export function asSubtype<T>(value: any): asserts value is T {
+	if (!(value || !value)) {
+		console.log('this is to assuage the linter');
+	}
+}

--- a/source/as-subtype.ts
+++ b/source/as-subtype.ts
@@ -8,11 +8,12 @@ If a impossible type conversion is performed the result will be never.
 You cannot expand a type; you may only reduce or translate to a similar type.
 
 @example
-```ts
-// this is particularly useful in async actions and
-// other modern framework applications (e.g. react)
+```
+// This is particularly useful in async actions and
+// other modern framework applications (for example, React)
+
 let isDefined = true;
-const foo = "bar" as string | null;
+const foo = 'bar' as string | null;
 
 if (foo === null) {
 	isDefined = false;
@@ -24,33 +25,33 @@ if (!isDefined) {
 	//=> foo === string
 }
 
-// you can also change between similar types
-const bar = ["bar"]
+// You can also change between similar types
+const bar = ['bar']
 //=> string[]
 asSubtype<[string]>(bar)
 //=> [string]
-asSubtype<["bar"]>(bar)
-//=> ["bar"]
+asSubtype<['bar']>(bar)
+//=> ['bar']
 
-// this can also break typescript invariants
-asSubtype<["string"]>(bar)
-//=> ["string"]
+// This can also break TypeScript invariants
+asSubtype<['string']>(bar)
+//=> ['string']
 // but only to a certain degree
 asSubtype<string>(bar)
-// => never
-asSubtype<number>("string")
 //=> never
-asSubtype<undefined>("string" as string | null)
+asSubtype<number>('string')
+//=> never
+asSubtype<undefined>('string' as string | null)
 //=> never
 
 // You can only increase precision
-const baz = "baz" as string | null;
+const baz = 'baz' as string | null;
 asSubtype<string>(baz)
 //=> string
 asSubtype<null | string>(baz)
 //=> string
 ```
- */
+*/
 export function asSubtype<T>(value: any): asserts value is T {
 	if (!(value || !value)) {
 		console.log('this is to assuage the linter');

--- a/source/index.ts
+++ b/source/index.ts
@@ -2,3 +2,4 @@ export {isDefined} from './is-defined.js';
 export {isEmpty} from './is-empty.js';
 export {assertError} from './assert-error.js';
 export {asMutable} from './as-mutable.js';
+export {asSubtype} from './as-subtype.js';

--- a/test/as-subtype.ts
+++ b/test/as-subtype.ts
@@ -1,0 +1,54 @@
+import test from 'ava';
+import {expectTypeOf} from 'expect-type';
+import {asSubtype} from '../source/index.js';
+
+test('isDefined()', t => {
+	// To assuage the linter
+	t.true(true);
+
+	let isDefined = true;
+	const foo = 'bar' as string | null;
+
+	if (foo === null) {
+		isDefined = false;
+	}
+
+	if (!isDefined) {
+		expectTypeOf(foo).toMatchTypeOf<string | null>();
+		asSubtype<string>(foo);
+		expectTypeOf(foo).toMatchTypeOf<string>();
+	}
+
+	// Similar types
+	const bar = ['bar'];
+	expectTypeOf(bar).toMatchTypeOf<string[]>();
+	asSubtype<[string]>(bar);
+	expectTypeOf(bar).toMatchTypeOf<[string]>();
+	asSubtype<['bar']>(bar);
+	expectTypeOf(bar).toMatchTypeOf<['bar']>();
+
+	// Invariant violation
+	asSubtype<['foo']>(bar);
+	// @ts-expect-error
+	expectTypeOf(bar).toMatchTypeOf<['foo']>();
+
+	// Never
+	asSubtype<string>(bar);
+	expectTypeOf(bar).toMatchTypeOf<never>();
+
+	const _test1_ = 'string';
+	asSubtype<number>('string');
+	// @ts-expect-error
+	expectTypeOf(_test1_).toBeNever();
+
+	const _test2_ = 'string' as string | null;
+	asSubtype<undefined>(_test2_);
+	expectTypeOf(_test2_).toBeNever();
+
+	// Attempt type expansion
+	const baz = 'baz' as string | null;
+	asSubtype<string>(baz);
+	expectTypeOf(baz).toMatchTypeOf<string>();
+	asSubtype<null | string>(baz);
+	expectTypeOf(baz).toMatchTypeOf<string>();
+});


### PR DESCRIPTION
I frequently run into edgecases that typescript has not addressed in their auto labeling of types. So I'm instead forced to redefine types or unnecessarily address supposedly nullable variables. This is a function to make overcoming these limitations easier.