### PR TITLE
Add `arrayIncludes()`

### DIFF
--- a/source/array-includes.ts
+++ b/source/array-includes.ts
@@ -1,7 +1,7 @@
 /**
-An alternative to `Array.prototype.includes` but acting as a type guard
+An alternative to `Array.prototype.includes` that properly acts as a type guard.
 
-The proposal was rejected in this issue: https://github.com/microsoft/TypeScript/issues/26255#issuecomment-748211891
+It was [rejected](https://github.com/microsoft/TypeScript/issues/26255#issuecomment-748211891) from being done in TypeScript itself.
 
 @example
 ```
@@ -11,7 +11,7 @@ const values = ['a', 'b', 'c'] as const;
 const valueToCheck: unknown = 'a';
 
 if (arrayIncludes(values, valueToCheck)) {
-	// Now we know that the value is of type `typeof values[number]`.
+	// We now know that the value is of type `typeof values[number]`.
 }
 ```
 */

--- a/source/array-includes.ts
+++ b/source/array-includes.ts
@@ -1,7 +1,7 @@
 /**
-A better version `Array.prototype.includes` which allows other types to be included and also acts as a type guard when the provided array is of a specific type.
+An alternative to `Array.prototype.includes` but acting as a type guard
 
-This is needed because `Array.prototype.includes` doesn't allow for other types to be included.
+The proposal was rejected in this issue: https://github.com/microsoft/TypeScript/issues/26255#issuecomment-748211891
 
 @example
 ```

--- a/source/array-includes.ts
+++ b/source/array-includes.ts
@@ -1,0 +1,24 @@
+/**
+A better version `Array.prototype.includes` which allows other types to be included and also acts as a type guard when the provided array is of a specific type.
+
+This is needed because `Array.prototype.includes` doesn't allow for other types to be included.
+
+@example
+```ts
+import {arrayIncludes} from 'ts-extras';
+
+const values = ['a', 'b', 'c'] as const;
+const valueToCheck: unknown = 'a';
+
+if (arrayIncludes(values, valueToCheck)) {
+  // Now we know that the value is of type `typeof values[number]`.
+}
+```
+*/
+export function arrayIncludes<Type>(
+	array: Type[] | readonly Type[],
+	item: unknown,
+	fromIndex?: number
+): item is Type {
+	return array.includes(item as Type, fromIndex);
+}

--- a/source/array-includes.ts
+++ b/source/array-includes.ts
@@ -4,14 +4,14 @@ A better version `Array.prototype.includes` which allows other types to be inclu
 This is needed because `Array.prototype.includes` doesn't allow for other types to be included.
 
 @example
-```ts
+```
 import {arrayIncludes} from 'ts-extras';
 
 const values = ['a', 'b', 'c'] as const;
 const valueToCheck: unknown = 'a';
 
 if (arrayIncludes(values, valueToCheck)) {
-  // Now we know that the value is of type `typeof values[number]`.
+	// Now we know that the value is of type `typeof values[number]`.
 }
 ```
 */

--- a/source/array-includes.ts
+++ b/source/array-includes.ts
@@ -18,7 +18,7 @@ if (arrayIncludes(values, valueToCheck)) {
 export function arrayIncludes<Type>(
 	array: Type[] | readonly Type[],
 	item: unknown,
-	fromIndex?: number
+	fromIndex?: number,
 ): item is Type {
 	return array.includes(item as Type, fromIndex);
 }

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,3 +1,4 @@
+export {arrayIncludes} from './array-includes.js';
 export {isDefined} from './is-defined.js';
 export {isEmpty} from './is-empty.js';
 export {assertError} from './assert-error.js';

--- a/test/array-includes.ts
+++ b/test/array-includes.ts
@@ -7,20 +7,16 @@ test('arrayIncludes()', t => {
 	const invalidValue: unknown = 'd';
 	let testValueType: typeof values[number];
 
-	t.is(arrayIncludes(values, validValue), true);
-	t.is(arrayIncludes(values, invalidValue), false);
+	t.true(arrayIncludes(values, validValue));
+	t.false(arrayIncludes(values, invalidValue));
 
+	// eslint-disable-next-line unicorn/prefer-ternary
 	if (arrayIncludes(values, validValue)) {
 		testValueType = validValue;
 	} else {
-		doNothing(); // Removes the `unicorn/prefer-ternary` failure;
 		// @ts-expect-error
 		testValueType = validValue;
 	}
 
 	t.is(testValueType, 'a');
 });
-
-function doNothing() {
-	// Do nothing
-}

--- a/test/array-includes.ts
+++ b/test/array-includes.ts
@@ -10,12 +10,19 @@ test('arrayIncludes()', t => {
 	t.true(arrayIncludes(values, validValue));
 	t.false(arrayIncludes(values, invalidValue));
 
-	// eslint-disable-next-line unicorn/prefer-ternary
 	if (arrayIncludes(values, validValue)) {
+		// @ts-expect-error
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		values.push(); // Ensure readonly array is still readonly.
+
 		testValueType = validValue;
 	} else {
 		// @ts-expect-error
 		testValueType = validValue;
+
+		// @ts-expect-error
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		values.push(); // Ensure readonly array is still readonly.
 	}
 
 	t.is(testValueType, 'a');

--- a/test/array-includes.ts
+++ b/test/array-includes.ts
@@ -1,0 +1,19 @@
+import test from 'ava';
+import {arrayIncludes} from '../source/index.js';
+
+test('arrayIncludes()', t => {
+	const values = ['a', 'b', 'c'] as const;
+	const validValue: unknown = 'a';
+	const invalidValue: unknown = 'd';
+	let testValueType: typeof values[number];
+
+	t.is(arrayIncludes(values, validValue), true);
+	t.is(arrayIncludes(values, invalidValue), false);
+
+	if (arrayIncludes(values, validValue)) {
+		testValueType = validValue;
+	} else {
+		// @ts-expect-error
+		testValueType = validValue;
+	}
+});

--- a/test/array-includes.ts
+++ b/test/array-includes.ts
@@ -13,7 +13,14 @@ test('arrayIncludes()', t => {
 	if (arrayIncludes(values, validValue)) {
 		testValueType = validValue;
 	} else {
+		doNothing(); // Removes the `unicorn/prefer-ternary` failure;
 		// @ts-expect-error
 		testValueType = validValue;
 	}
+
+	t.is(testValueType, 'a');
 });
+
+function doNothing() {
+	// Do nothing
+}


### PR DESCRIPTION
### Description

This adds an improved `arrayIncludes` function which acts as a type guard.

```ts
import {arrayIncludes} from 'ts-extras';

const values = ['a', 'b', 'c'] as const;
declare const valueToCheck: unknown;
let value: typeof values[number];

if (arrayIncludes(values, valueToCheck)) {
  // Now we know that the value is of type `typeof values[number]`.
  value = valueToCheck
} else {
  // @ts-expect-error
  value = valueToCheck
}
```

