### PR TITLE
Add `objectKeys()`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -2,3 +2,4 @@ export {isDefined} from './is-defined.js';
 export {isEmpty} from './is-empty.js';
 export {assertError} from './assert-error.js';
 export {asMutable} from './as-mutable.js';
+export {objectKeys} from './object-keys.js';

--- a/source/object-keys.ts
+++ b/source/object-keys.ts
@@ -1,10 +1,10 @@
 /**
 A strongly-typed version of `Object.keys()`.
 
-- Closed in issue: https://github.com/microsoft/TypeScript/issues/45390
-- Reasoning: https://stackoverflow.com/questions/55012174/why-doesnt-object-keys-return-a-keyof-type-in-typescript
+This is useful since `Object.keys()` always returns an array of strings. This function returns a strongly-typed array of the keys of the given object.
 
-This is useful since `Object.keys()` returns an array of strings. This function returns a strongly-typed array of the keys of the given object.
+- [Explanation](https://stackoverflow.com/questions/55012174/why-doesnt-object-keys-return-a-keyof-type-in-typescript)
+- [TypeScript issues about this](https://github.com/microsoft/TypeScript/issues/45390)
 
 @example
 ```

--- a/source/object-keys.ts
+++ b/source/object-keys.ts
@@ -4,6 +4,8 @@ A strongly-typed version of `Object.keys()`.
 - Closed in issue: https://github.com/microsoft/TypeScript/issues/45390
 - Reasoning: https://stackoverflow.com/questions/55012174/why-doesnt-object-keys-return-a-keyof-type-in-typescript
 
+This is useful since `Object.keys()` returns an array of strings. This function returns a strongly-typed array of the keys of the given object.
+
 @example
 ```ts
 import {objectKeys} from 'ts-extras';

--- a/source/object-keys.ts
+++ b/source/object-keys.ts
@@ -1,0 +1,20 @@
+/**
+A typed implementation of `Object.keys()`.
+
+This is useful since `Object.keys()` returns an array of strings. This function returns an array of the type keys of the given object.
+
+@example
+```ts
+import {objectKeys} from 'ts-extras';
+
+type Item = ['a', 'b', 'c'];
+declare let: items: Item[];
+
+items = objectKeys({a: 1, b: 2, c: 3}); // This is valid.
+```
+*/
+export function objectKeys<Type extends Record<string, unknown>, Key extends Extract<keyof Type, string>>(
+	value: Type,
+): Key[] {
+	return Object.keys(value) as Key[];
+}

--- a/source/object-keys.ts
+++ b/source/object-keys.ts
@@ -1,16 +1,15 @@
 /**
-A typed implementation of `Object.keys()`.
+A strongly-typed version of `Object.keys()`.
 
-This is useful since `Object.keys()` returns an array of strings. This function returns an array of the type keys of the given object.
+- Closed in issue: https://github.com/microsoft/TypeScript/issues/45390
+- Reasoning: https://stackoverflow.com/questions/55012174/why-doesnt-object-keys-return-a-keyof-type-in-typescript
 
 @example
 ```ts
 import {objectKeys} from 'ts-extras';
 
-type Item = ['a', 'b', 'c'];
-declare let: items: Item[];
-
-items = objectKeys({a: 1, b: 2, c: 3}); // This is valid.
+const stronglyTypedItems = objectKeys({a: 1, b: 2, c: 3}); // => Array<'a' | 'b' | 'c'>
+const untypedItems = Object.keys(items); // => Array<string>
 ```
 */
 export function objectKeys<Type extends Record<string, unknown>, Key extends Extract<keyof Type, string>>(

--- a/source/object-keys.ts
+++ b/source/object-keys.ts
@@ -7,7 +7,7 @@ A strongly-typed version of `Object.keys()`.
 This is useful since `Object.keys()` returns an array of strings. This function returns a strongly-typed array of the keys of the given object.
 
 @example
-```ts
+```
 import {objectKeys} from 'ts-extras';
 
 const stronglyTypedItems = objectKeys({a: 1, b: 2, c: 3}); // => Array<'a' | 'b' | 'c'>

--- a/test/object-keys.ts
+++ b/test/object-keys.ts
@@ -1,0 +1,11 @@
+import test from 'ava';
+import {expectTypeOf} from 'expect-type';
+import {objectKeys} from '../source/index.js';
+
+test('objectKeys()', t => {
+	type Item = 'a' | 'b' | 'c';
+	const items = objectKeys({a: 1, b: 2, c: 3});
+
+	expectTypeOf<Item[]>(items);
+	t.deepEqual(items, ['a', 'b', 'c']);
+});


### PR DESCRIPTION
### Description

A typed implementation of `Object.keys()`.

This is useful since `Object.keys()` returns an array of strings. This function returns an array of the type keys of the given object.

@example
```ts
import {objectKeys} from 'ts-extras';

type Item = ['a', 'b', 'c'];
declare let: items: Item[];

items = objectKeys({a: 1, b: 2, c: 3}); // This is valid.
```