### PR TITLE
Add `objectEntries()`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -4,3 +4,4 @@ export {isEmpty} from './is-empty.js';
 export {assertError} from './assert-error.js';
 export {asMutable} from './as-mutable.js';
 export {objectKeys} from './object-keys.js';
+export {objectEntries} from './object-entries.js';

--- a/source/object-entries.ts
+++ b/source/object-entries.ts
@@ -13,6 +13,6 @@ const stronglyTypedEntries = objectEntries({a: 1, b: 2, c: 3}); // =>  Array<["a
 const untypedEntries = Object.entries(items); // => Array<[string, number]>
 ```
 */
-export function objectEntries<Type extends Record<PropertyKey, unknown>, Key extends Exclude<keyof Type, symbol>>(value: Type): Array<[Key, Type[Key]]> {
+export function objectEntries<Type extends Record<PropertyKey, unknown>, Key extends `${Exclude<keyof Type, symbol>}`>(value: Type): Array<[Key, Type[Key]]> {
 	return Object.entries(value) as Array<[Key, Type[Key]]>;
 }

--- a/source/object-entries.ts
+++ b/source/object-entries.ts
@@ -1,7 +1,7 @@
 /**
 A strongly-typed version of `Object.entries()`.
 
-This is useful since `Object.entries()` always returns an array of Array<[string, T]>. This function returns a strongly-typed array of the entries of the given object.
+This is useful since `Object.entries()` always returns an array of `Array<[string, T]>`. This function returns a strongly-typed array of the entries of the given object.
 
 - [TypeScript issues about this](https://github.com/microsoft/TypeScript/pull/12253)
 
@@ -9,8 +9,11 @@ This is useful since `Object.entries()` always returns an array of Array<[string
 ```
 import {objectEntries} from 'ts-extras';
 
-const stronglyTypedEntries = objectEntries({a: 1, b: 2, c: 3}); // =>  Array<["a" | "b" | "c", number]>
-const untypedEntries = Object.entries(items); // => Array<[string, number]>
+const stronglyTypedEntries = objectEntries({a: 1, b: 2, c: 3});
+//=> Array<['a' | 'b' | 'c', number]>
+
+const untypedEntries = Object.entries(items);
+//=> Array<[string, number]>
 ```
 */
 export function objectEntries<Type extends Record<PropertyKey, unknown>, Key extends `${Exclude<keyof Type, symbol>}`>(value: Type): Array<[Key, Type[Key]]> {

--- a/source/object-entries.ts
+++ b/source/object-entries.ts
@@ -1,0 +1,21 @@
+/**
+A strongly-typed version of `Object.entries()`.
+
+This is useful since `Object.entries()` always returns an array of Array<[string, T]>. This function returns a strongly-typed array of the entries of the given object.
+
+- [TypeScript issues about this](https://github.com/microsoft/TypeScript/pull/12253)
+
+@example
+```
+import {objectEntries} from 'ts-extras';
+
+const stronglyTypedEntries = objectEntries({a: 1, b: 2, c: 3}); // =>  Array<["a" | "b" | "c", number]>
+const untypedEntries = Object.entries(items); // => Array<[string, number]>
+```
+*/
+export function objectEntries<Type extends Record<string, unknown>, Key extends Extract<keyof Type, string>>(
+	value: Type,
+): Array<[Key, Type[Key]]> {
+	return Object.entries(value) as Array<[Key, Type[Key]]>;
+}
+

--- a/source/object-entries.ts
+++ b/source/object-entries.ts
@@ -13,9 +13,6 @@ const stronglyTypedEntries = objectEntries({a: 1, b: 2, c: 3}); // =>  Array<["a
 const untypedEntries = Object.entries(items); // => Array<[string, number]>
 ```
 */
-export function objectEntries<Type extends Record<string, unknown>, Key extends Extract<keyof Type, string>>(
-	value: Type,
-): Array<[Key, Type[Key]]> {
+export function objectEntries<Type extends Record<PropertyKey, unknown>, Key extends Exclude<keyof Type, symbol>>(value: Type): Array<[Key, Type[Key]]> {
 	return Object.entries(value) as Array<[Key, Type[Key]]>;
 }
-

--- a/test/object-entries.ts
+++ b/test/object-entries.ts
@@ -3,7 +3,7 @@ import {expectTypeOf} from 'expect-type';
 import {objectEntries} from '../source/index.js';
 
 test('objectEntries()', t => {
-	type Entry = [1 | 'stringKey', number | string];
+	type Entry = ['1' | 'stringKey', number | string];
 	const entries = objectEntries({
 		1: 123,
 		stringKey: 'someString',

--- a/test/object-entries.ts
+++ b/test/object-entries.ts
@@ -1,0 +1,11 @@
+import test from 'ava';
+import {expectTypeOf} from 'expect-type';
+import {objectEntries} from '../source/index.js';
+
+test('objectEntries()', t => {
+	type Entry = ['a' | 'b' | 'c', number];
+	const entries = objectEntries({a: 1, b: 2, c: 3});
+
+	expectTypeOf<Entry[]>(entries);
+	t.deepEqual(entries, [['a', 1], ['b', 2], ['c', 3]]);
+});

--- a/test/object-entries.ts
+++ b/test/object-entries.ts
@@ -3,9 +3,13 @@ import {expectTypeOf} from 'expect-type';
 import {objectEntries} from '../source/index.js';
 
 test('objectEntries()', t => {
-	type Entry = ['a' | 'b' | 'c', number];
-	const entries = objectEntries({a: 1, b: 2, c: 3});
+	type Entry = [1 | 'stringKey', number | string];
+	const entries = objectEntries({
+		1: 123,
+		stringKey: 'someString',
+		[Symbol('symbolKey')]: true,
+	});
 
 	expectTypeOf<Entry[]>(entries);
-	t.deepEqual(entries, [['a', 1], ['b', 2], ['c', 3]]);
+	t.deepEqual(entries, [['1', 123], ['stringKey', 'someString']]);
 });


### PR DESCRIPTION
## Description

This adds a strongly-typed version of `Object.entries()` function.

Close #11 