### PR TITLE
Fix return type of `objectKeys()`

### DIFF
--- a/source/object-entries.ts
+++ b/source/object-entries.ts
@@ -1,3 +1,5 @@
+import {ObjectKeys} from './object-keys';
+
 /**
 A strongly-typed version of `Object.entries()`.
 
@@ -16,6 +18,6 @@ const untypedEntries = Object.entries(items);
 //=> Array<[string, number]>
 ```
 */
-export function objectEntries<Type extends Record<PropertyKey, unknown>, Key extends `${Exclude<keyof Type, symbol>}`>(value: Type): Array<[Key, Type[Key]]> {
-	return Object.entries(value) as Array<[Key, Type[Key]]>;
+export function objectEntries<Type extends Record<PropertyKey, unknown>>(value: Type): Array<[ObjectKeys<Type>, Type[ObjectKeys<Type>]]> {
+	return Object.entries(value) as Array<[ObjectKeys<Type>, Type[ObjectKeys<Type>]]>;
 }

--- a/source/object-keys.ts
+++ b/source/object-keys.ts
@@ -1,3 +1,5 @@
+export type ObjectKeys<T extends Record<PropertyKey, unknown>> = `${Exclude<keyof T, symbol>}`;
+
 /**
 A strongly-typed version of `Object.keys()`.
 
@@ -14,8 +16,6 @@ const stronglyTypedItems = objectKeys({a: 1, b: 2, c: 3}); // => Array<'a' | 'b'
 const untypedItems = Object.keys(items); // => Array<string>
 ```
 */
-export function objectKeys<Type extends Record<string, unknown>, Key extends Extract<keyof Type, string>>(
-	value: Type,
-): Key[] {
-	return Object.keys(value) as Key[];
+export function objectKeys<Type extends Record<PropertyKey, unknown>>(value: Type): Array<ObjectKeys<Type>> {
+	return Object.keys(value) as Array<ObjectKeys<Type>>;
 }

--- a/test/object-keys.ts
+++ b/test/object-keys.ts
@@ -3,8 +3,8 @@ import {expectTypeOf} from 'expect-type';
 import {objectKeys} from '../source/index.js';
 
 test('objectKeys()', t => {
-	type Item = 'a' | 'b' | 'c';
-	const items = objectKeys({a: 1, b: 2, c: 3});
+	type Item = 'a' | 'b' | 'c' | '4';
+	const items = objectKeys({a: 1, b: 2, c: 3, 4: 4, [Symbol('5')]: 5});
 
 	expectTypeOf<Item[]>(items);
 	t.deepEqual(items, ['a', 'b', 'c']);

--- a/test/object-keys.ts
+++ b/test/object-keys.ts
@@ -7,5 +7,5 @@ test('objectKeys()', t => {
 	const items = objectKeys({a: 1, b: 2, c: 3, 4: 4, [Symbol('5')]: 5});
 
 	expectTypeOf<Item[]>(items);
-	t.deepEqual(items, ['a', 'b', 'c']);
+	t.deepEqual(items, ['a', 'b', 'c', '4']);
 });

--- a/test/object-keys.ts
+++ b/test/object-keys.ts
@@ -7,5 +7,5 @@ test('objectKeys()', t => {
 	const items = objectKeys({a: 1, b: 2, c: 3, 4: 4, [Symbol('5')]: 5});
 
 	expectTypeOf<Item[]>(items);
-	t.deepEqual(items, ['a', 'b', 'c', '4']);
+	t.deepEqual(items, ['4', 'a', 'b', 'c']);
 });


### PR DESCRIPTION
Resolves #13 

Implements the same type logic as #12.