### PR TITLE
Add `isFinite`, `isInteger`, and `isSafeInteger`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"helpers"
 	],
 	"dependencies": {
-		"type-fest": "^2.6.0"
+		"type-fest": "^2.7.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,9 @@ import {isDefined} from 'ts-extras';
 - [`arrayIncludes`](source/array-includes.ts) - An alternative to `Array#includes()` that properly acts as a type guard.
 - [`objectKeys`](source/object-keys.ts) - A strongly-typed version of `Object.entries()`.
 - [`objectEntries`](source/object-entries.ts) - A strongly-typed version of `Object.keys()`.
+- [`isFinite`](source/is-finite.ts) - A strongly-typed version of `Number.isFinite()`.
+- [`isInteger`](source/is-integer.ts) - A strongly-typed version of `Number.isInteger()`.
+- [`isSafeInteger`](source/is-safe-integer.ts) - A strongly-typed version of `Number.isSafeInteger()`.
 
 ## FAQ
 

--- a/source/is-finite.ts
+++ b/source/is-finite.ts
@@ -1,0 +1,11 @@
+import {Finite} from 'type-fest';
+
+/**
+An alternative to `Number.isFinite()` that properly acts as a type guard.
+
+@category Improved builtin
+@category Type guard
+*/
+export function isFinite<T extends number>(value: T): value is Finite<T> {
+	return Number.isFinite(value);
+}

--- a/source/is-integer.ts
+++ b/source/is-integer.ts
@@ -1,0 +1,11 @@
+import {Integer} from 'type-fest';
+
+/**
+An alternative to `Number.isInteger()` that properly acts as a type guard.
+
+@category Improved builtin
+@category Type guard
+*/
+export function isInteger<T extends number>(value: T): value is Integer<T> {
+	return Number.isInteger(value);
+}

--- a/source/is-safe-integer.ts
+++ b/source/is-safe-integer.ts
@@ -1,0 +1,11 @@
+import {Integer} from 'type-fest';
+
+/**
+An alternative to `Number.isSafeInteger()` that properly acts as a type guard.
+
+@category Improved builtin
+@category Type guard
+*/
+export function isSafeInteger<T extends number>(value: T): value is Integer<T> {
+	return Number.isSafeInteger(value);
+}


### PR DESCRIPTION
Adds `isFinite`, `isInteger`, and `isInteger` helper functions that make use of type-fest's numeric types.

Fixes #16
Fixes #17
Fixes #18