### PR TITLE
Add `objectFromEntries()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ import {isDefined} from 'ts-extras';
 - [`arrayIncludes`](source/array-includes.ts) - An alternative to `Array#includes()` that properly acts as a type guard.
 - [`objectKeys`](source/object-keys.ts) - A strongly-typed version of `Object.keys()`.
 - [`objectEntries`](source/object-entries.ts) - A strongly-typed version of `Object.entries()`.
+- [`objectFromEntries`](source/object-from-entries.ts) - A strongly-typed version of `Object.fromEntries()`.
 - [`objectHasOwn`](source/object-has-own.ts) - A strongly-typed version of `Object.hasOwn()`.
 - [`isFinite`](source/is-finite.ts) - A strongly-typed version of `Number.isFinite()`.
 - [`isInteger`](source/is-integer.ts) - A strongly-typed version of `Number.isInteger()`.

--- a/source/index.ts
+++ b/source/index.ts
@@ -4,5 +4,6 @@ export {isEmpty} from './is-empty.js';
 export {asMutable} from './as-mutable.js';
 export {arrayIncludes} from './array-includes.js';
 export {objectKeys} from './object-keys.js';
+export {objectFromEntries} from './object-from-entries.js';
 export {objectEntries} from './object-entries.js';
 export {objectHasOwn} from './object-has-own.js';

--- a/source/object-entries.ts
+++ b/source/object-entries.ts
@@ -24,3 +24,4 @@ const untypedEntries = Object.entries(items);
 export function objectEntries<Type extends Record<PropertyKey, unknown>>(value: Type): Array<[ObjectKeys<Type>, Type[ObjectKeys<Type>]]> {
 	return Object.entries(value) as Array<[ObjectKeys<Type>, Type[ObjectKeys<Type>]]>;
 }
+

--- a/source/object-entries.ts
+++ b/source/object-entries.ts
@@ -24,4 +24,3 @@ const untypedEntries = Object.entries(items);
 export function objectEntries<Type extends Record<PropertyKey, unknown>>(value: Type): Array<[ObjectKeys<Type>, Type[ObjectKeys<Type>]]> {
 	return Object.entries(value) as Array<[ObjectKeys<Type>, Type[ObjectKeys<Type>]]>;
 }
-

--- a/source/object-from-entries.ts
+++ b/source/object-from-entries.ts
@@ -1,7 +1,7 @@
 /**
 A strongly-typed version of `Object.fromEntries()`.
 
-This is useful since `Object.fromEntries()` always returns `{ [k: string]: T }`. This function returns a strongly-typed object from given array of entries.
+This is useful since `Object.fromEntries()` always returns `{[key: string]: T}`. This function returns a strongly-typed object from the given array of entries.
 
 - [TypeScript issues about this](https://github.com/microsoft/TypeScript/issues/35745)
 

--- a/source/object-from-entries.ts
+++ b/source/object-from-entries.ts
@@ -14,14 +14,10 @@ const stronglyTypedObjectFromEntries = objectFromEntries([
 	['b', 'someString'],
 	['c', true],
 ]);
-//=> {
-	a: number;
-	b: string;
-	c: boolean;
-}
+//=> {a: number; b: string; c: boolean}
 
 const untypedEntries = Object.fromEntries(entries);
-//=> { [k: string]: string; }
+//=> {[key: string]: string}
 ```
 
 @category Improved builtin

--- a/source/object-from-entries.ts
+++ b/source/object-from-entries.ts
@@ -27,10 +27,10 @@ const untypedEntries = Object.fromEntries(entries);
 @category Improved builtin
 @category Type guard
 */
-export function objectFromEntries<Key extends PropertyKey, Entries extends Array<[Key, any]>>(value: Entries): {
-	[K in Extract<Entries[number], [Key, any]>[0]]: Extract<Entries[number], [K, any]>[1]
+export function objectFromEntries<Key extends PropertyKey, Entries extends Array<[Key, unknown]>>(value: Entries): {
+	[K in Extract<Entries[number], [Key, unknown]>[0]]: Extract<Entries[number], [K, unknown]>[1]
 } {
 	return Object.fromEntries(value) as {
-		[K in Extract<Entries[number], [Key, any]>[0]]: Extract<Entries[number], [K, any]>[1]
+		[K in Extract<Entries[number], [Key, unknown]>[0]]: Extract<Entries[number], [K, unknown]>[1]
 	};
 }

--- a/source/object-from-entries.ts
+++ b/source/object-from-entries.ts
@@ -1,0 +1,36 @@
+/**
+A strongly-typed version of `Object.fromEntries()`.
+
+This is useful since `Object.fromEntries()` always returns `{ [k: string]: T }`. This function returns a strongly-typed object from given array of entries.
+
+- [TypeScript issues about this](https://github.com/microsoft/TypeScript/issues/35745)
+
+@example
+```
+import {objectFromEntries} from 'ts-extras';
+
+const stronglyTypedObjectFromEntries = objectFromEntries([
+	['a', 123],
+	['b', 'someString'],
+	['c', true],
+]);
+//=> {
+	a: number;
+	b: string;
+	c: boolean;
+}
+
+const untypedEntries = Object.fromEntries(entries);
+//=> { [k: string]: string; }
+```
+
+@category Improved builtin
+@category Type guard
+*/
+export function objectFromEntries<Key extends PropertyKey, Entries extends Array<[Key, any]>>(value: Entries): {
+	[K in Extract<Entries[number], [Key, any]>[0]]: Extract<Entries[number], [K, any]>[1]
+} {
+	return Object.fromEntries(value) as {
+		[K in Extract<Entries[number], [Key, any]>[0]]: Extract<Entries[number], [K, any]>[1]
+	};
+}

--- a/test/object-from-entries.ts
+++ b/test/object-from-entries.ts
@@ -1,0 +1,26 @@
+import test from 'ava';
+import {expectTypeOf} from 'expect-type';
+import {objectFromEntries} from '../source/index.js';
+
+test('objectFromEntries()', t => {
+	type ObjectFromEntries = {
+		[x: symbol]: boolean;
+		1: number;
+		stringKey: string;
+	};
+
+	const symbolKey = Symbol('symbolKey');
+
+	const objectFromEntries_ = objectFromEntries([
+		[1, 123],
+		['stringKey', 'someString'],
+		[symbolKey, true],
+	]);
+
+	expectTypeOf<ObjectFromEntries>(objectFromEntries_);
+	t.deepEqual(objectFromEntries_, {
+		1: 123,
+		stringKey: 'someString',
+		[symbolKey]: true,
+	});
+});


### PR DESCRIPTION
A strongly-typed version of `Object.fromEntries()`.

It is useful to infer object type from array of entries.