### PR TITLE
Fix `objectFromEntries()` to support `readonly`

### DIFF
--- a/source/object-from-entries.ts
+++ b/source/object-from-entries.ts
@@ -23,8 +23,8 @@ const untypedEntries = Object.fromEntries(entries);
 @category Improved builtin
 @category Type guard
 */
-export function objectFromEntries<Key extends PropertyKey, Entries extends Array<[Key, unknown]>>(value: Entries): {
-	[K in Extract<Entries[number], [Key, unknown]>[0]]: Extract<Entries[number], [K, unknown]>[1]
+export function objectFromEntries<Key extends PropertyKey, Entries extends ReadonlyArray<readonly [Key, unknown]>>(value: Entries): {
+	[K in Extract<Entries[number], readonly [Key, unknown]>[0]]: Extract<Entries[number], readonly [K, unknown]>[1]
 } {
 	return Object.fromEntries(value) as {
 		[K in Extract<Entries[number], [Key, unknown]>[0]]: Extract<Entries[number], [K, unknown]>[1]

--- a/test/object-from-entries.ts
+++ b/test/object-from-entries.ts
@@ -23,4 +23,17 @@ test('objectFromEntries()', t => {
 		stringKey: 'someString',
 		[symbolKey]: true,
 	});
+
+	const objectFromReadonlyEntries_ = objectFromEntries([
+		[1, 123],
+		['stringKey', 'someString'],
+		[symbolKey, true],
+	] as const);
+
+	expectTypeOf<ObjectFromEntries>(objectFromReadonlyEntries_);
+	t.deepEqual(objectFromReadonlyEntries_, {
+		1: 123,
+		stringKey: 'someString',
+		[symbolKey]: true,
+	});
 });


### PR DESCRIPTION
resolve #35 