### PR TITLE
Fix support for `interface` value in `objectKeys`

### DIFF
--- a/source/object-keys.ts
+++ b/source/object-keys.ts
@@ -1,4 +1,6 @@
-export type ObjectKeys<T extends Record<PropertyKey, unknown>> = `${Exclude<keyof T, symbol>}`;
+/* eslint-disable @typescript-eslint/ban-types */
+
+export type ObjectKeys<T extends object> = `${Exclude<keyof T, symbol>}`;
 
 /**
 A strongly-typed version of `Object.keys()`.
@@ -19,6 +21,6 @@ const untypedItems = Object.keys(items); // => Array<string>
 @category Improved builtin
 @category Type guard
 */
-export function objectKeys<Type extends Record<PropertyKey, unknown>>(value: Type): Array<ObjectKeys<Type>> {
+export function objectKeys<Type extends object>(value: Type): Array<ObjectKeys<Type>> {
 	return Object.keys(value) as Array<ObjectKeys<Type>>;
 }

--- a/test/object-keys.ts
+++ b/test/object-keys.ts
@@ -2,10 +2,19 @@ import test from 'ava';
 import {expectTypeOf} from 'expect-type';
 import {objectKeys} from '../source/index.js';
 
+interface TestInterface {
+	e: string;
+	f: number;
+}
+
 test('objectKeys()', t => {
 	type Item = 'a' | 'b' | 'c' | '4';
 	const items = objectKeys({a: 1, b: 2, c: 3, 4: 4, [Symbol('5')]: 5});
-
 	expectTypeOf<Item[]>(items);
 	t.deepEqual(items, ['4', 'a', 'b', 'c']);
+
+	const interfaceInput: TestInterface = {e: 'a', f: 1};
+	const interfaceItems = objectKeys(interfaceInput);
+	expectTypeOf<Array<keyof TestInterface>>(interfaceItems);
+	t.deepEqual(interfaceItems, ['e', 'f']);
 });


### PR DESCRIPTION
Previously, `objectKeys` caused type errors when called with any value declared from an `interface`.

```ts
import { objectKeys } from 'ts-extras';

interface MyInterface {
  some: string;
  value: number;
}

type MyType = {
  some: string;
  value: number;
};

declare const withInterface: MyInterface;
declare const withType: MyType;

objectKeys(withInterface); // => ❌ ERROR
objectKeys(withType); // => ✅ PASS 
```

Closes #50