### PR TITLE
Run `tsc` on test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	},
 	"scripts": {
 		"build": "del-cli distribution && tsc",
-		"test": "xo && ava && npm run build",
+		"test": "xo && ava && tsc -p test && npm run build",
 		"prepack": "npm run build"
 	},
 	"files": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	},
 	"scripts": {
 		"build": "del-cli distribution && tsc",
-		"test": "xo && ava && tsc -p test && npm run build",
+		"test": "xo && ava && tsc --project test && npm run build",
 		"prepack": "npm run build"
 	},
 	"files": [

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@sindresorhus/tsconfig",
+	"include": ["."],
+	"compilerOptions": {
+		"noEmit": true
+	}
+}


### PR DESCRIPTION
Because [expect-type](https://www.npmjs.com/package/expect-type) is "Compile-time tests for types", `npm run test` shows success even if the associated type test fails. So I think it's safer to run `tsx` on the test file while `npm run test`