### PR TITLE
Stricter `objectFromEntries`

### DIFF
--- a/source/object-from-entries.ts
+++ b/source/object-from-entries.ts
@@ -24,5 +24,5 @@ const untypedEntries = Object.fromEntries(entries);
 @category Type guard
 */
 export const objectFromEntries = Object.fromEntries as <Key extends PropertyKey, Entries extends ReadonlyArray<readonly [Key, unknown]>>(values: Entries) => {
-	[K in Extract<Entries[number], readonly [Key, unknown]>[0]]: Extract<Entries[number], readonly [K, unknown]>[1]
+	[K in Extract<Entries[number], readonly [Key, unknown]>[0]]?: Extract<Entries[number], readonly [K, unknown]>[1]
 };


### PR DESCRIPTION
## Why make this change?

It’s [possible that the compiler incorrectly assumes keys are defined](https://www.typescriptlang.org/play/?noUncheckedIndexedAccess=true&target=11#code/MYewdgzgLgBCBGArApsKAxATiAtgUTCkwEtkIYBeGAeSVSgDoAzbfQksmAQ3IB4BpZAE8YyAB5RkYACbkACtgAOyTFCGChAGhgEipcuMkzyAJWRdp4ADZCAgpkxchvTOctgbMANobtAVzAAazAQAHcwAF0APiiACgA3Lis-MgAuHXZ9AEpKKJgAbwAoAEgfGGIwHQlHNF5dDggvMD8ceBUI7VcLaxEfYX8gkPDorwAGCIj0vGquWvr9Jpa2zA6YLvdPHwHgsMiorwBGCMKAXwBuGBhCwtBIWC4HdPtHZy8AIls37SOYAB9vN4AIS+MAATNFKN4ImdClZkLAQJCECg0FhcPMyLEHpgsjCAPR4y4APQA-NcbuAICA4QwrCAAOaxEAMWwwADUcAYgNxMAJMFCxCsVhgTC4gv5xCgAAsYAA5LiywpAA).

Feel free to disregard if you do not believe this to be an actual issue. [Here’s what this change does to the compiler](https://www.typescriptlang.org/play/?noUncheckedIndexedAccess=true&target=11#code/MYewdgzgLgBCBGArApsKAxATiAtgUTCkwEtkIYBeGAeSVSgDoAzbfQksmAQ3IB4BpZAE8YyAB5RkYACbkACtgAOyTFCGChAGhgEipcuMkzyAJWRdp4ADZCAgpkxchvTOctgbMANobtAVzAAazAQAHcwAF0APiiACgA3Lis-MgAuHXZ9AEpKKJgAbwAoAEgfGGIwHQlHNF5dDggvMD8ceBUI7VcLaxEfYX8gkPDorwAGCIiAfnS8aq5a+v0mlrbMDpgu908fAeCwyKivAEYIwoBfAG4Ya5vbu-uHx6fn24B6V4A9GCgAC2JyACOKWgxHAMBwXEwgXKBggECkUGISRghUKoEgsEhmHS9kczi8ACJbATtCcYAAfbwEgBCJJgACZopRvBELoUrMhYCBmQgUGgsLhFmRYlismz3tcPpNUaj0RAQByGFYQABzWIgBi2GAAajgDGpYpgEtADnonmI0gRxCY+m+Py4sF+FRV5FAfis0hgbRgAUtNrAyGkQA).

Note that in both of these examples I assumed `noUncheckedIndexedAccess` is true, which would make the this kind of bug especially surprising to anyone that enabled that feature…